### PR TITLE
Refactor: 네이버지도로 변경

### DIFF
--- a/src/Pages/MainPage/MainPage.tsx
+++ b/src/Pages/MainPage/MainPage.tsx
@@ -1,6 +1,5 @@
 import styled from "styled-components";
-import Kakaomap from "./Kakaomap/Kakaomap";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { HEADER_HEIGHT } from "../../Constants/constant";
 import axios from "axios";
 import useStore from "../../zustand/store/ContentStore";
@@ -14,7 +13,6 @@ import { Icon } from "../DetailPage/style";
 import NaverMap from "./NaverMap/NaverMap";
 
 function MainPage() {
-  const mapRef = useRef<HTMLElement | null>(null);
   const { updateTotalData } = useStore((state) => state);
   const navigate = useNavigate();
 

--- a/src/Pages/MainPage/MainPage.tsx
+++ b/src/Pages/MainPage/MainPage.tsx
@@ -11,6 +11,7 @@ import { useNavigate } from "react-router-dom";
 import SvgRefreshButton from "../../assets/svg/RefreshButton";
 import SvgBacktoCurrentButton from "../../assets/svg/BacktoCurrentButton";
 import { Icon } from "../DetailPage/style";
+import NaverMap from "./NaverMap/NaverMap";
 
 function MainPage() {
   const mapRef = useRef<HTMLElement | null>(null);
@@ -72,7 +73,8 @@ function MainPage() {
             />
           </Icon>
         </Icons>
-        <Kakaomap mapRef={mapRef} />
+        {/* <Kakaomap mapRef={mapRef} /> */}
+        <NaverMap />
         <Bottom>
           <BottomSheet />
           <Buttons>

--- a/src/Pages/MainPage/NaverMap/NaverMap.tsx
+++ b/src/Pages/MainPage/NaverMap/NaverMap.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import CurrentLocation from "../Kakaomap/CurrentLocation";
 
 declare global {
   interface Window {
@@ -11,22 +12,30 @@ declare global {
 function NaverMap() {
   const mapElement = useRef(null);
   const { naver } = window;
+  const currentLocation = CurrentLocation();
+  const latitude = Number(localStorage.getItem("latitude"));
+  const longitude = Number(localStorage.getItem("longitude"));
 
   useEffect(() => {
     if (!mapElement.current || !naver) return;
 
-    // 지도에 표시할 위치의 위도와 경도 좌표를 파라미터로 넣어줍니다.
-    const location = new naver.maps.LatLng(37.5656, 126.9769);
+    const location = new naver.maps.LatLng(latitude, longitude);
     const mapOptions = {
       center: location,
-      zoom: 17,
-      zoomControl: true,
+      zoom: 15,
+      zoomControl: false,
     };
 
     const map = new naver.maps.Map(mapElement.current, mapOptions);
     new naver.maps.Marker({
       position: location,
       map,
+      icon: {
+        url: "../../../public/svg/CurrentLocationIcon.svg",
+        size: new naver.maps.Size(50, 52),
+        origin: new naver.maps.Point(0, 0),
+        anchor: new naver.maps.Point(25, 26),
+      },
     });
   }, []);
 

--- a/src/Pages/QuickMatch/MatchNaverMap/NaverMap.tsx
+++ b/src/Pages/QuickMatch/MatchNaverMap/NaverMap.tsx
@@ -8,7 +8,7 @@ declare global {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
-function NaverMap() {
+function MatchNaverMap() {
   const mapElement = useRef(null);
   const { naver } = window;
   const latitude = Number(localStorage.getItem("latitude"));
@@ -44,4 +44,4 @@ function NaverMap() {
   );
 }
 
-export default NaverMap;
+export default MatchNaverMap;

--- a/src/Pages/QuickMatch/QuickMatchFinding.tsx
+++ b/src/Pages/QuickMatch/QuickMatchFinding.tsx
@@ -1,4 +1,3 @@
-import { useRef } from "react";
 import DetailHeader from "../DetailPage/DetailHeader";
 import {
   ContentDetail,

--- a/src/Pages/QuickMatch/QuickMatchFinding.tsx
+++ b/src/Pages/QuickMatch/QuickMatchFinding.tsx
@@ -19,12 +19,11 @@ import {
   LocationMarker,
 } from "../../assets/svg";
 import { useLocation } from "react-router";
-import MatchKaKao from "./MatchKakao/MatchKakao";
 import CurrentLocationStore from "../../zustand/store/CurrentLocation";
+import NaverMap from "../MainPage/NaverMap/NaverMap";
+import styled from "styled-components";
 
 function QuickMatchFinding() {
-  const mapRef = useRef<HTMLElement | null>(null);
-
   const location = useLocation();
 
   const { destination } = location.state;
@@ -35,23 +34,14 @@ function QuickMatchFinding() {
     <div>
       <DetailHeader />
       <S.Container style={{ gap: "9px" }}>
-        <S.Discription style={{ marginTop: "10px" }}>
+        <S.Discription style={{ marginTop: "10px", zIndex: 3 }}>
           <Title>
             지금 가까운 팟을 <br />
             찾고 있어요
           </Title>
           <ContentDetail>조금만 기다려주세요</ContentDetail>
         </S.Discription>
-        <div
-          style={{
-            width: "100vw",
-            height: "44vh",
-            backgroundColor: "white",
-            zIndex: "2",
-            opacity: "0.5",
-            marginTop: "10px",
-          }}
-        />
+        <WhiteOpacity />
         <Icon
           style={{
             position: "absolute",
@@ -66,9 +56,8 @@ function QuickMatchFinding() {
         <div
           style={{
             position: "absolute",
-            zIndex: 3,
-            top: "30vh",
-
+            zIndex: 4,
+            top: "31vh",
             left: "36vw",
             width: "200px",
             marginLeft: "-50px",
@@ -76,23 +65,14 @@ function QuickMatchFinding() {
         >
           <GreenOpacity width="200" height="200" />
         </div>
-        <div
-          style={{
-            position: "absolute",
-            top: "200px",
-            width: "100vw",
-            height: "320px",
-            backgroundColor: "aliceblue",
-          }}
-        >
-          <MatchKaKao mapRef={mapRef} />
-        </div>
+        <MapWrapper>
+          <NaverMap />
+        </MapWrapper>
         <Route
           style={{
-            position: "absolute",
-            top: "66%",
+            display: "flex",
             height: "115px",
-            zIndex: "2",
+            zIndex: "3",
             backgroundColor: "white",
             paddingTop: "31px",
             paddingLeft: "25px",
@@ -145,4 +125,20 @@ function QuickMatchFinding() {
   );
 }
 
+const WhiteOpacity = styled.div`
+  position: absolute;
+  width: 100vw;
+  height: 100%;
+  background-color: white;
+  z-index: 2;
+  opacity: 0.5;
+  margin-top: 10px;
+`;
+
+const MapWrapper = styled.div`
+  z-index: 1;
+  width: 100vw;
+  height: 44vh;
+  background-color: aliceblue;
+`;
 export default QuickMatchFinding;


### PR DESCRIPTION
close #37 

## Key Changes
- 메인페이지 및 가까운 팟 찾기 페이지를 네이버 지도로 변경하였습니다.
- 네이버 지도 api에는 건물 이름을 알려주는 api는 없어 이 부분은 카카오맵 api를 이용했습니다.

## 스크린샷
<img width="415" alt="image" src="https://github.com/TeamFighting/Moyeota-Web/assets/108210492/b1b89414-8776-4f93-9d4e-e6e91bc951c1">
<img width="406" alt="image" src="https://github.com/TeamFighting/Moyeota-Web/assets/108210492/40c27716-c2cf-4206-a9d7-cf680ed212b4">
