### PR TITLE
Feat: 팟 자세히보기 기능 구현

### DIFF
--- a/src/Pages/MainPage/Components/MarkerClickContent/MarkerClickContent.tsx
+++ b/src/Pages/MainPage/Components/MarkerClickContent/MarkerClickContent.tsx
@@ -7,17 +7,21 @@ import createAgo from "../SingleContent/createAgo";
 import { Clock, ProfileSample } from "../../../../assets/svg";
 import getDays from "../SingleContent/getDays";
 import ISOto12 from "../SingleContent/ISOto12";
+import { useNavigate } from "react-router";
 
 function MarkerClickContent({ postId: postId }: { postId: number }) {
+  const navigate = useNavigate();
   const { totalData } = ContentStore((state) => state);
-  console.log("totalData", totalData);
-  console.log("postId", postId);
   const data = totalData.find((data) => data.postId === postId);
-  console.log("data", data);
   const ago = createAgo(data.createAt);
   const splitedDay = getDays(data.departureTime);
   const timePart = ISOto12(data.departureTime);
-
+  const goToDetail = () => {
+    navigate(`/detailPage/${postId}`, {
+      state: { data, splitedDay, timePart },
+    });
+    window.location.href = `/detailPage/${postId}`;
+  };
   let gender = "";
   if (!data.userGender) {
     gender = "여";
@@ -73,7 +77,7 @@ function MarkerClickContent({ postId: postId }: { postId: number }) {
               )}
             </S.Time>
           </S.Info>
-          <ShowDetail>팟 자세히 보기</ShowDetail>
+          <ShowDetail onClick={goToDetail}>팟 자세히 보기</ShowDetail>
         </div>
       </BriefWrapper>
     </div>

--- a/src/Pages/MainPage/Components/MarkerClickContent/MarkerClickContent.tsx
+++ b/src/Pages/MainPage/Components/MarkerClickContent/MarkerClickContent.tsx
@@ -16,12 +16,13 @@ function MarkerClickContent({ postId: postId }: { postId: number }) {
   const ago = createAgo(data.createAt);
   const splitedDay = getDays(data.departureTime);
   const timePart = ISOto12(data.departureTime);
+
   const goToDetail = () => {
     navigate(`/detailPage/${postId}`, {
       state: { data, splitedDay, timePart },
     });
-    window.location.href = `/detailPage/${postId}`;
   };
+
   let gender = "";
   if (!data.userGender) {
     gender = "여";
@@ -127,6 +128,6 @@ const ShowDetail = styled.div`
   display: flex;
   border-radius: 12px;
   margin: 0 auto;
-  margin-top: 8px;
+  margin-top: 13px;
 `;
 export default MarkerClickContent;

--- a/src/Pages/MainPage/Components/SingleContent/index.tsx
+++ b/src/Pages/MainPage/Components/SingleContent/index.tsx
@@ -18,9 +18,10 @@ function SingleContent() {
   const navigateToDetail = (
     data: object,
     splitedDay: string[],
-    timePart: string
+    timePart: string,
+    postId: number
   ) => {
-    navigate("/detailpage", {
+    navigate(`/detailpage/${postId}`, {
       state: {
         data: data,
         splitedDay: splitedDay,
@@ -35,6 +36,7 @@ function SingleContent() {
     const splitedDay = getDays(data.departureTime);
     const timePart = ISOto12(data.departureTime);
     const ago = createAgo(data.createAt);
+    const postId = data.postId;
     let gender;
 
     if (!data.userGender) {
@@ -47,7 +49,7 @@ function SingleContent() {
       <S.SingleContent
         key={index}
         onClick={() => {
-          navigateToDetail(data, splitedDay, timePart);
+          navigateToDetail(data, splitedDay, timePart, postId);
         }}
       >
         <Profile

--- a/src/Pages/MainPage/NaverMap/NaverMap.tsx
+++ b/src/Pages/MainPage/NaverMap/NaverMap.tsx
@@ -130,13 +130,12 @@ function NaverMap() {
 
     function getClickHandler(seq: any) {
       return function (e: any) {
-        console.log("click", e);
-        console.log("seq", seq);
         const marker = markers[seq];
         setClickedMarker(marker.postId);
       };
     }
 
+    // 클릭 이벤트
     for (let i = 0, ii = markers.length; i < ii; i++) {
       naver.maps.Event.addListener(markers[i], "click", getClickHandler(i));
     }

--- a/src/Pages/MainPage/NaverMap/NaverMap.tsx
+++ b/src/Pages/MainPage/NaverMap/NaverMap.tsx
@@ -129,7 +129,7 @@ function NaverMap() {
     }
 
     function getClickHandler(seq: any) {
-      return function (e: any) {
+      return function () {
         const marker = markers[seq];
         setClickedMarker(marker.postId);
       };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,7 +21,7 @@ const router = createBrowserRouter([
     element: <MainPage />,
   },
   {
-    path: "/detailPage",
+    path: "/detailPage/:postId",
     element: <DetailPage />,
   },
   {


### PR DESCRIPTION
close #54 

## Motivation
- 자세히보기 버튼 클릭시 data, timepart, splitedTime을 state로 가지고 navigate됩니다.

## Key Changes
- detailPage로 라우팅 시 /detailPage/postId로 이동합니다.

## 스크린 샷
![53:feat](https://github.com/TeamFighting/Moyeota-Web/assets/108210492/9e476162-e9c2-4ead-8cca-0d00fae1f54d)
