### PR TITLE
Feat: 안 읽은 메시지 갯수 구현

### DIFF
--- a/src/Pages/FirebaseChat/ChatLists.tsx
+++ b/src/Pages/FirebaseChat/ChatLists.tsx
@@ -32,7 +32,7 @@ function ChatLists() {
     const [chatRooms, setChatRooms] = useState<ChatRoomProps[]>([]);
     const [roomIds, setRoomIds] = useState<string[]>([]);
     const navigate = useNavigate();
-    const { noneReadChat, lastReadTime, setNoneReadChat, setLastReadTime } = NoneReadChatStore.getState();
+    const { noneReadChat, lastReadTime, setNoneReadChat, setLastReadTime } = NoneReadChatStore();
     useEffect(() => {
         totalChatRooms();
         for (let i = 0; i < chatRooms.length; i++) {
@@ -45,9 +45,8 @@ function ChatLists() {
         // 메시지의 시간이 마지막으로 읽은 시간 이후인지 확인
         const lastReadTime = NoneReadChatStore.getState().lastReadTime[roomId];
         if (message.timestamp > lastReadTime) {
-            // 만약 그렇다면, 읽지 않은 메시지의 개수를 1 증가시킴
-            const noneReadCount = noneReadChat[roomId] || 0;
-            setNoneReadChat(roomId, noneReadCount + 1);
+            console.log('new ');
+            setNoneReadChat(roomId, noneReadChat[roomId] + 1);
         }
     }
 
@@ -59,6 +58,7 @@ function ChatLists() {
         });
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         setChatRooms(res.data.data);
+        console.log('chatRooms', res.data.data);
     };
     // 채팅방에 메시지가 도착할 때 호출
 
@@ -101,15 +101,12 @@ function ChatLists() {
                 }
             }
             messages.sort((a, b) => b.timestamp - a.timestamp);
-            setLastMessage(messages); // setLastMessage를 사용하여 상태 업데이트
-            if (
-                lastMessage[0].key == messages[0].key &&
-                lastMessage[0].timestamp == messages[0].timestamp &&
-                lastMessage[0].text == messages[0].text
-            ) {
+            if (lastMessage.length === 0) return setLastMessage(messages);
+            if (lastMessage[0].timestamp == messages[0].timestamp && lastMessage[0].text == messages[0].text) {
                 console.log('same message');
             } else {
                 console.log('new message');
+                setLastMessage(messages); // setLastMessage를 사용하여 상태 업데이트
                 onMessageArrived(messages[0].key, messages[0]);
             }
         });

--- a/src/Pages/FirebaseChat/ChatLists.tsx
+++ b/src/Pages/FirebaseChat/ChatLists.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { instance } from '../../axios';
 import { useNavigate } from 'react-router';
 import styled from 'styled-components';
-import { ref as dbRef, query, onValue, set } from 'firebase/database';
+import { ref as dbRef, query, onValue } from 'firebase/database';
 import { db } from '../../firebase';
 import { Chevronleft, Plus } from '../../assets/svg';
 import moment from 'moment';

--- a/src/Pages/FirebaseChat/index.tsx
+++ b/src/Pages/FirebaseChat/index.tsx
@@ -47,7 +47,7 @@ function FirebaseChat() {
     const [messagesLoading, setMessagesLoading] = useState<boolean>(true);
 
     const { id, name, profileImage } = JSON.parse(localStorage.getItem('myInfo') as string);
-    const { setLastReadTime, setNoneReadChat, setResetNoneReadChat } = NoneReadChatStore.getState();
+    const { setLastReadTime, setNoneReadChat } = NoneReadChatStore.getState();
     const navigate = useNavigate();
     const handleBack = () => {
         leaveChatRoom(roomId);

--- a/src/Pages/FirebaseChat/index.tsx
+++ b/src/Pages/FirebaseChat/index.tsx
@@ -12,6 +12,7 @@ import moment from 'moment';
 import 'moment/locale/ko';
 import Skeleton from '../../components/Skeleton';
 import { showProfileTime } from '../util/showProfileTime';
+import { NoneReadChatStore } from '../../state/store/NoneReadChat';
 interface ChatPageProps {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     postId: string;
@@ -49,7 +50,8 @@ function FirebaseChat() {
 
     const navigate = useNavigate();
     const handleBack = () => {
-        navigate(-1);
+        navigate('/ChatLists');
+        leaveChatRoom(roomId);
     };
     const messageEndRef = useRef<HTMLDivElement>(null);
     const messagesRef = dbRef(db, 'messages');
@@ -69,6 +71,11 @@ function FirebaseChat() {
     useEffect(() => {
         if (roomId !== undefined) addMessagesListener(roomId);
     }, [roomId]);
+
+    function leaveChatRoom(roomId: string) {
+        NoneReadChatStore.getState().setLastReadTime(roomId, Date.now());
+        NoneReadChatStore.getState().setNoneReadChat(roomId, 0);
+    }
 
     const addMessagesListener = (roomId: string) => {
         const messagesArray = [] as myMessageProps[];

--- a/src/Pages/FirebaseChat/index.tsx
+++ b/src/Pages/FirebaseChat/index.tsx
@@ -47,11 +47,11 @@ function FirebaseChat() {
     const [messagesLoading, setMessagesLoading] = useState<boolean>(true);
 
     const { id, name, profileImage } = JSON.parse(localStorage.getItem('myInfo') as string);
-
+    const { setLastReadTime, setNoneReadChat, setResetNoneReadChat } = NoneReadChatStore.getState();
     const navigate = useNavigate();
     const handleBack = () => {
-        navigate('/ChatLists');
         leaveChatRoom(roomId);
+        navigate('/ChatLists');
     };
     const messageEndRef = useRef<HTMLDivElement>(null);
     const messagesRef = dbRef(db, 'messages');
@@ -73,8 +73,8 @@ function FirebaseChat() {
     }, [roomId]);
 
     function leaveChatRoom(roomId: string) {
-        NoneReadChatStore.getState().setLastReadTime(roomId, Date.now());
-        NoneReadChatStore.getState().setNoneReadChat(roomId, 0);
+        setLastReadTime(roomId, Date.now());
+        setNoneReadChat(roomId, 0);
     }
 
     const addMessagesListener = (roomId: string) => {
@@ -86,8 +86,7 @@ function FirebaseChat() {
         });
         setMessagesLoading(false);
     };
-    const createMessage = (fileUrl: string | null = null) => {
-        console.log(fileUrl);
+    const createMessage = () => {
         if (newMessage === '') return;
         const message = {
             key: roomId,

--- a/src/state/store/AppliedPartyStore.ts
+++ b/src/state/store/AppliedPartyStore.ts
@@ -1,19 +1,28 @@
-import { create } from 'zustand'
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 type State = {
-    appliedParty: Array<{ postId: number; isApplied: boolean }>
-    setAppliedParty: (postId: number) => void
-    deleteAppliedParty: (postId: number) => void
-}
+    appliedParty: Array<{ postId: number; isApplied: boolean }>;
+    setAppliedParty: (postId: number) => void;
+    deleteAppliedParty: (postId: number) => void;
+};
 
-export const useAppliedPartyStore = create<State>((set) => ({
-    appliedParty: [],
-    setAppliedParty: (postId) =>
-        set((state) => ({
-            appliedParty: [...state.appliedParty, { postId: postId, isApplied: true }],
-        })),
-    deleteAppliedParty: (postId) =>
-        set((state) => ({
-            appliedParty: [...state.appliedParty.filter((party) => party.postId !== postId)],
-        })),
-}))
+export const useAppliedPartyStore = create(
+    persist<State>(
+        (set) => ({
+            appliedParty: [],
+            setAppliedParty: (postId) =>
+                set((state) => ({
+                    appliedParty: [...state.appliedParty, { postId: postId, isApplied: true }],
+                })),
+            deleteAppliedParty: (postId) =>
+                set((state) => ({
+                    appliedParty: [...state.appliedParty.filter((party) => party.postId !== postId)],
+                })),
+        }),
+        {
+            name: 'applied-party',
+            getStorage: () => sessionStorage,
+        },
+    ),
+);

--- a/src/state/store/AuthStore.ts
+++ b/src/state/store/AuthStore.ts
@@ -1,12 +1,21 @@
 import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
 
 interface AuthStore {
     accessToken: string;
     setAccessToken: (token: string) => void;
 }
 
-export const AuthStore = create<AuthStore>((set) => ({
-    accessToken:
-        'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxNSIsImV4cCI6MTcwOTU2OTQyNn0.oUeDuvpNMaXspU0W-MM74Rsjd5mWZRwgRt2O9Pp0nkU',
-    setAccessToken: (token: string) => set(() => ({ accessToken: token })),
-}));
+export const AuthStore = create(
+    persist<AuthStore>(
+        (set) => ({
+            accessToken:
+                'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxNSIsImV4cCI6MTcwOTU2OTQyNn0.oUeDuvpNMaXspU0W-MM74Rsjd5mWZRwgRt2O9Pp0nkU',
+            setAccessToken: (token: string) => set(() => ({ accessToken: token })),
+        }),
+        {
+            name: 'auth-storage',
+            storage: createJSONStorage(() => sessionStorage),
+        },
+    ),
+);

--- a/src/state/store/NoneReadChat.ts
+++ b/src/state/store/NoneReadChat.ts
@@ -12,8 +12,13 @@ export const NoneReadChatStore = create(
         (set) => ({
             noneReadChat: {},
             lastReadTime: {},
-            setNoneReadChat: (roomId, count) =>
-                set((state) => ({ noneReadChat: { ...state.noneReadChat, [roomId]: count } })),
+            setNoneReadChat: (roomId) =>
+                set((state) => ({
+                    noneReadChat: {
+                        ...state.noneReadChat,
+                        [roomId]: (state.noneReadChat[roomId] || 0) + 1,
+                    },
+                })),
             setLastReadTime: (roomId, time) =>
                 set((state) => ({ lastReadTime: { ...state.lastReadTime, [roomId]: time } })),
         }),

--- a/src/state/store/NoneReadChat.ts
+++ b/src/state/store/NoneReadChat.ts
@@ -1,10 +1,15 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
+import { LastMessageProps } from '../../Pages/FirebaseChat/ChatLists';
+
 interface NoneReadChatProps {
     noneReadChat: { [roomId: string]: number };
     lastReadTime: { [roomId: string]: number };
-    setNoneReadChat: (roomId: string, count: number) => void;
+    lastMessage: LastMessageProps[];
+    setNoneReadChat: (roomId: string, num?: number) => void;
     setLastReadTime: (roomId: string, time: number) => void;
+    setResetNoneReadChat: (roomId: string) => void;
+    setLastMessage: (message: LastMessageProps[]) => void;
 }
 
 export const NoneReadChatStore = create(
@@ -12,15 +17,35 @@ export const NoneReadChatStore = create(
         (set) => ({
             noneReadChat: {},
             lastReadTime: {},
-            setNoneReadChat: (roomId) =>
-                set((state) => ({
-                    noneReadChat: {
-                        ...state.noneReadChat,
-                        [roomId]: (state.noneReadChat[roomId] || 0) + 1,
-                    },
-                })),
+            lastMessage: [],
+            setNoneReadChat: (roomId, num) =>
+                set((state) => {
+                    return ((num) => {
+                        if (num !== undefined && num === 0) {
+                            return {
+                                noneReadChat: {
+                                    ...state.noneReadChat,
+                                    [roomId]: 0,
+                                },
+                            };
+                        } else {
+                            return {
+                                noneReadChat: {
+                                    ...state.noneReadChat,
+                                    [roomId]: (state.noneReadChat[roomId] || 0) + 1,
+                                },
+                            };
+                        }
+                    })(num);
+                }),
             setLastReadTime: (roomId, time) =>
                 set((state) => ({ lastReadTime: { ...state.lastReadTime, [roomId]: time } })),
+            setResetNoneReadChat: (roomId) => {
+                set({ noneReadChat: { [roomId]: 0 } });
+            },
+            setLastMessage: (message) => {
+                set({ lastMessage: message });
+            },
         }),
         { storage: createJSONStorage(() => sessionStorage), name: 'noneReadChat' },
     ),

--- a/src/state/store/NoneReadChat.ts
+++ b/src/state/store/NoneReadChat.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+interface NoneReadChatProps {
+    noneReadChat: { [roomId: string]: number };
+    lastReadTime: { [roomId: string]: number };
+    setNoneReadChat: (roomId: string, count: number) => void;
+    setLastReadTime: (roomId: string, time: number) => void;
+}
+
+export const NoneReadChatStore = create(
+    persist<NoneReadChatProps>(
+        (set) => ({
+            noneReadChat: {},
+            lastReadTime: {},
+            setNoneReadChat: (roomId, count) =>
+                set((state) => ({ noneReadChat: { ...state.noneReadChat, [roomId]: count } })),
+            setLastReadTime: (roomId, time) =>
+                set((state) => ({ lastReadTime: { ...state.lastReadTime, [roomId]: time } })),
+        }),
+        { storage: createJSONStorage(() => sessionStorage), name: 'noneReadChat' },
+    ),
+);

--- a/src/state/store/PotCreateStore.ts
+++ b/src/state/store/PotCreateStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 interface StoreState {
     description: string;
@@ -21,25 +22,33 @@ interface StoreState {
     setPostId: (value: number) => void;
 }
 
-const PotCreateStore = create<StoreState>((set) => ({
-    description: '',
-    title: '',
-    distance: 0,
-    destination: null,
-    totalPeople: 1,
-    VehicleType: '일반',
-    sameGenderRide: 'NO',
-    selectedTime: '',
-    postId: 0,
-    setDescription: (value) => set({ description: value }),
-    setTitle: (value) => set({ title: value }),
-    setDistance: (value) => set({ distance: value }),
-    setDestination: (value) => set({ destination: value }),
-    setTotalPeople: (value: number) => set({ totalPeople: value }),
-    setVehicleType: (value) => set({ VehicleType: value }),
-    setSameGenderRide: (value) => set({ sameGenderRide: value }),
-    setSelectedTime: (value) => set({ selectedTime: value }),
-    setPostId: (value: number) => set({ postId: value }),
-}));
+const PotCreateStore = create(
+    persist<StoreState>(
+        (set) => ({
+            description: '',
+            title: '',
+            distance: 0,
+            destination: null,
+            totalPeople: 1,
+            VehicleType: '일반',
+            sameGenderRide: 'NO',
+            selectedTime: '',
+            postId: 0,
+            setDescription: (value) => set({ description: value }),
+            setTitle: (value) => set({ title: value }),
+            setDistance: (value) => set({ distance: value }),
+            setDestination: (value) => set({ destination: value }),
+            setTotalPeople: (value: number) => set({ totalPeople: value }),
+            setVehicleType: (value) => set({ VehicleType: value }),
+            setSameGenderRide: (value) => set({ sameGenderRide: value }),
+            setSelectedTime: (value) => set({ selectedTime: value }),
+            setPostId: (value: number) => set({ postId: value }),
+        }),
+        {
+            name: 'PotCreateStore',
+            getStorage: () => sessionStorage,
+        },
+    ),
+);
 
 export default PotCreateStore;

--- a/src/state/store/QuickMathDestinationStore.ts
+++ b/src/state/store/QuickMathDestinationStore.ts
@@ -1,11 +1,20 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 type QuickMathDestinationStore = {
     destination: string;
     setDestination: (destination: string) => void;
 };
 
-export const useQuickMathDestinationStore = create<QuickMathDestinationStore>((set) => ({
-    destination: '',
-    setDestination: (destination) => set({ destination }),
-}));
+export const useQuickMathDestinationStore = create(
+    persist<QuickMathDestinationStore>(
+        (set) => ({
+            destination: '',
+            setDestination: (destination) => set({ destination }),
+        }),
+        {
+            name: 'QuickMathDestinationStore',
+            getStorage: () => sessionStorage,
+        },
+    ),
+);


### PR DESCRIPTION
close #98 

## Motivation
- zustand-persist를 이용해 안 읽은 메시지 갯수를 카운팅했습니다.
- 내가 채팅방에 들어갔다 나온 시간을 기준으로 새로 온 메시지의 시간을 비교해 카운팅 해주었습니다.
- 만일 내가 보낸 메시지가 아니고, 내가 채팅방을 나간 시간 이후에 온 채팅이라면 안 읽은 메시지로 간주해 카운팅 해주었습니다.

## 스크린샷
![안 읽은 메시지 카운팅 기능 구현](https://github.com/TeamFighting/Moyeota-Web/assets/108210492/c237322c-9265-414f-93a5-07811475e11b)


