### PR TITLE
Feat: 채팅창 Enter key 이벤트 등록 및 메시지 전송 후 채팅창으로 포커싱

### DIFF
--- a/src/Pages/FirebaseChat/index.tsx
+++ b/src/Pages/FirebaseChat/index.tsx
@@ -45,10 +45,10 @@ function FirebaseChat() {
     const [newMessage, setNewMessage] = useState<string>('');
     const [messages, setMessages] = useState<myMessageProps[]>([]);
     const [messagesLoading, setMessagesLoading] = useState<boolean>(true);
-
     const { id, name, profileImage } = JSON.parse(localStorage.getItem('myInfo') as string);
     const { setLastReadTime, setNoneReadChat } = NoneReadChatStore.getState();
     const navigate = useNavigate();
+    const inputRef = useRef<HTMLInputElement>(null);
     const handleBack = () => {
         leaveChatRoom(roomId);
         navigate('/ChatLists');
@@ -107,8 +107,15 @@ function FirebaseChat() {
             if (roomId === undefined) return;
             await set(push(child(messagesRef, roomId)), createMessage());
             setNewMessage('');
+            inputRef.current?.focus();
         } catch (e) {
             console.log(e);
+        }
+    };
+
+    const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter') {
+            sendMessage();
         }
     };
 
@@ -175,12 +182,14 @@ function FirebaseChat() {
             <S.Bottom>
                 <S.InputWrapper>
                     <S.StyledInput
+                        ref={inputRef}
                         placeholder="메시지 보내기..."
                         onChange={(e) => {
                             setNewMessage(e.target.value);
                         }}
                         value={newMessage}
                         type="text"
+                        onKeyPress={handleKeyPress}
                     />
                     <div
                         style={{


### PR DESCRIPTION
close #100 

## Motivation
- useRef를 사용해 input 태그에 ref를 지정하고, sendMessage 함수가 실행되면 InputRef에 focus가 맞춰지도록 구현했습니다.
- 엔터키 이벤트를 등록해 채팅창에 메시지 입력한 상태로 엔터키를 누르면 메시지가 보내지도록 이벤트를 등록했습니다.

## Key Changes

~가 변경되었습니다.

## 스크린샷
![채팅 엔터키 이벤트 등록](https://github.com/TeamFighting/Moyeota-Web/assets/108210492/c6feb51d-aa63-441f-9f8e-04f933cb9cb4)
![input 태그 오토포커싱](https://github.com/TeamFighting/Moyeota-Web/assets/108210492/2b5a10d0-1e46-4cfc-97cd-bf5891006b86)

## To Reviewers

~를 중점으로 보면서 검토해주세요
