### PR TITLE
Hotfix:  팟이 없을 경우 UI 처리 및 404 대응

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,5 +1,6 @@
 import ProtectedRoute from '@components/ProtectRoute/ProtectRoute';
 import { ROUTE } from '@constants/route';
+import NotFound from '@pages/404Page';
 import LoginPage from '@pages/LoginPage';
 import LoginLoading from '@pages/LoginPage/LoadingLogin';
 import { lazy, Suspense } from 'react';
@@ -68,7 +69,7 @@ export const Router = () => {
                 <Route path={ROUTE.MYPAGE_MANAGE_PROFILE} element={<ProtectedRoute element={<ManageProfile />} />} />
                 <Route path={ROUTE.SELECT_GENDER_AGE} element={<ProtectedRoute element={<SelectGenderAge />} />} />
                 <Route path={ROUTE.MY_POT} element={<ProtectedRoute element={<MyPot />} />} />
-                <Route path="*" element={<div>404</div>} />
+                <Route path="*" element={<NotFound />} />
             </Routes>
         </Suspense>
     );

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -68,6 +68,7 @@ export const Router = () => {
                 <Route path={ROUTE.MYPAGE_MANAGE_PROFILE} element={<ProtectedRoute element={<ManageProfile />} />} />
                 <Route path={ROUTE.SELECT_GENDER_AGE} element={<ProtectedRoute element={<SelectGenderAge />} />} />
                 <Route path={ROUTE.MY_POT} element={<ProtectedRoute element={<MyPot />} />} />
+                <Route path="*" element={<div>404</div>} />
             </Routes>
         </Suspense>
     );

--- a/src/hooks/UI/useBottonSheet.ts
+++ b/src/hooks/UI/useBottonSheet.ts
@@ -53,6 +53,7 @@ export default function useBottomSheet({ from, setIsBottomSheetOpen }: BottomShe
         // 컨텐츠 영역 터치시 바텀시트가 올라가지 않도록
         const canUserMoveBottomSheet = () => {
             const { touchMove, isContentAreaTouched } = metrics.current;
+
             const scrollTop = content.current!.scrollTop;
             if (isContentAreaTouched && scrollTop > 0) {
                 return false;

--- a/src/pages/404Page/index.tsx
+++ b/src/pages/404Page/index.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+import styled from 'styled-components';
+
+function NotFound() {
+    useEffect(() => {
+        setTimeout(() => {
+            window.location.href = '/mainpage';
+        }, 3000);
+    }, []);
+    return (
+        <Wrapper>
+            🙀
+            <br /> 어머나 잘못 찾아오셨어요 !
+            <br />
+            <DetailText> 3초 후 메인페이지로 이동합니다...</DetailText>
+        </Wrapper>
+    );
+}
+
+export default NotFound;
+
+const Wrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    position: fixed;
+    justify-content: center;
+    align-items: center;
+    font-size: 28px;
+    font-weight: 600;
+    z-index: 1;
+    width: 100%;
+    height: 100dvh;
+    text-align: center;
+    transition: transform 400ms ease-out;
+`;
+
+export const DetailText = styled.div`
+    font-size: 20px;
+    font-weight: 400;
+    margin-top: 10px;
+`;

--- a/src/pages/MainPage/Components/BottomSheet/BottomSheetContent.tsx
+++ b/src/pages/MainPage/Components/BottomSheet/BottomSheetContent.tsx
@@ -7,10 +7,10 @@ interface BottomSheetContentProps {
 }
 const BottomSheetContent = ({ content }: BottomSheetContentProps) => {
     const { totalData } = useStore((state) => state);
-    console.log(totalData);
     if (totalData.length === 0) {
         return (
             <div
+                ref={content}
                 style={{
                     width: '100%',
                     justifyContent: 'center',

--- a/src/pages/MainPage/Components/BottomSheet/BottomSheetContent.tsx
+++ b/src/pages/MainPage/Components/BottomSheet/BottomSheetContent.tsx
@@ -7,8 +7,8 @@ interface BottomSheetContentProps {
 }
 const BottomSheetContent = ({ content }: BottomSheetContentProps) => {
     const { totalData } = useStore((state) => state);
-
-    if (totalData === undefined || null) {
+    console.log(totalData);
+    if (totalData.length === 0) {
         return (
             <div
                 style={{
@@ -24,13 +24,15 @@ const BottomSheetContent = ({ content }: BottomSheetContentProps) => {
                 <img src="/public/png/Simbol.png" />
                 <p
                     style={{
-                        fontSize: '32px',
+                        fontSize: '24px',
                         fontFamily: 'pretendard',
                         color: ' #9A9A9A',
                         fontWeight: 500,
+                        textAlign: 'center',
                     }}
                 >
-                    데이터가 없습니다 :(
+                    아직 팟이 없어요 ! <br />
+                    팟을 만들어 택시비를 아껴보세요 :)
                 </p>
             </div>
         );


### PR DESCRIPTION
close #175 

## Motivation
- totalContent의 길이가 0일 경우 bottomSheet에 빈 화면이 나타나 사용자 경험을 저해햐였습니다.
- 이에 아래 이미지와 같이 UI를 구현했습니다.
- 404 페이지를 만들고, 404 페이지에 들어오면 3초 후 메인페이지로 라우팅 시켰습니다. 


## 스크린샷
<img width="402" alt="image" src="https://github.com/user-attachments/assets/2f3c527e-0559-49c0-9eb6-740134d628f2">
<img width="395" alt="image" src="https://github.com/user-attachments/assets/38d35303-7d7a-4d7a-bbc9-ac7a1a2ba14c">


